### PR TITLE
Factor out rule parsing and logic and create a second overridable BoolOrString

### DIFF
--- a/overridable/bool.go
+++ b/overridable/bool.go
@@ -1,160 +1,69 @@
-// Package overridable provides data types representing values in campaign
-// specs that can be overridden for specific repositories.
 package overridable
 
-import (
-	"encoding/json"
-
-	"github.com/gobwas/glob"
-	"github.com/pkg/errors"
-)
+import "encoding/json"
 
 // Bool represents a bool value that can be modified on a per-repo basis.
 type Bool struct {
-	rules []*boolRule
-}
-
-// allPattern is used to define default rules for the simple scalar case.
-const allPattern = "*"
-
-// boolRule encapsulates a compiled glob pattern and its corresponding value.
-type boolRule struct {
-	pattern  string
-	compiled glob.Glob
-	value    bool
+	rules rules
 }
 
 // FromBool creates a Bool representing a static, scalar value.
 func FromBool(b bool) Bool {
-	rule, err := newBoolRule(allPattern, b)
-	if err != nil {
-		// Since we control the pattern being compiled, an error should never
-		// occur.
-		panic(err)
-	}
-
 	return Bool{
-		rules: []*boolRule{rule},
+		rules: rules{SimpleRule(b)},
 	}
 }
 
 // Value returns the bool value for the given repository.
 func (b *Bool) Value(name string) bool {
-	// We want the last match to win, so we'll iterate in reverse order.
-	for i := len(b.rules) - 1; i >= 0; i-- {
-		if b.rules[i].compiled.Match(name) {
-			return b.rules[i].value
-		}
+	v := b.rules.Match(name)
+	if v == nil {
+		return false
 	}
-
-	// If nothing matched, we'll treat the value as false.
-	return false
+	return v.(bool)
 }
 
-// MarshalJSON marshalls the bool into its JSON representation, which will
-// either be a boolean literal or an array of objects.
-func (b Bool) MarshalJSON() ([]byte, error) {
+// MarshalJSON encodes the Bool overridable to a json representation.
+func (b *Bool) MarshalJSON() ([]byte, error) {
 	if len(b.rules) == 0 {
-		return json.Marshal(false)
-	} else if len(b.rules) == 1 && b.rules[0].pattern == allPattern {
-		return json.Marshal(b.rules[0].value)
+		return []byte("false"), nil
 	}
-
-	rules := []map[string]bool{}
-	for _, rule := range b.rules {
-		rules = append(rules, map[string]bool{
-			rule.pattern: rule.value,
-		})
-	}
-	return json.Marshal(rules)
+	return json.Marshal(b.rules)
 }
 
 // UnmarshalJSON unmarshalls a JSON value into a Bool.
 func (b *Bool) UnmarshalJSON(data []byte) error {
 	var all bool
 	if err := json.Unmarshal(data, &all); err == nil {
-		*b = FromBool(all)
+		*b = Bool{rules: rules{SimpleRule(all)}}
 		return nil
 	}
 
-	var bc boolComplex
-	if err := json.Unmarshal(data, &bc); err != nil {
+	var c complex
+	if err := json.Unmarshal(data, &c); err != nil {
 		return err
 	}
 
-	return bc.hydrate(b)
+	return b.rules.hydrateFromComplex(c)
 }
 
 // UnmarshalYAML unmarshalls a YAML value into a Bool.
 func (b *Bool) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var all bool
 	if err := unmarshal(&all); err == nil {
-		*b = FromBool(all)
+		*b = Bool{rules: rules{SimpleRule(all)}}
 		return nil
 	}
 
-	var bc boolComplex
-	if err := unmarshal(&bc); err != nil {
+	var c complex
+	if err := unmarshal(&c); err != nil {
 		return err
 	}
 
-	return bc.hydrate(b)
+	return b.rules.hydrateFromComplex(c)
 }
 
-// newBoolRule builds a new boolRule instance, ensuring that the glob pattern
-// is compiled.
-func newBoolRule(pattern string, value bool) (*boolRule, error) {
-	compiled, err := glob.Compile(pattern)
-	if err != nil {
-		return nil, err
-	}
-
-	return &boolRule{
-		pattern:  pattern,
-		compiled: compiled,
-		value:    value,
-	}, nil
-}
-
-// boolComplex is used internally as a helper when marshalling and
-// unmarshalling Bool instances that are not simple, scalar values.
-type boolComplex []map[string]bool
-
-// hydrate builds an array of rules out of a boolComplex value.
-func (bc boolComplex) hydrate(b *Bool) error {
-	b.rules = make([]*boolRule, len(bc))
-	for i, rule := range bc {
-		if len(rule) != 1 {
-			return errors.Errorf("unexpected number of elements in the array at entry %d: %d (must be 1)", i, len(rule))
-		}
-		for pattern, value := range rule {
-			var err error
-			b.rules[i], err = newBoolRule(pattern, value)
-			if err != nil {
-				return errors.Wrapf(err, "building rule for array entry %d", i)
-			}
-		}
-	}
-
-	return nil
-}
-
-// Define equality methods required for cmp to be able to work its magic.
-
-func (a Bool) Equal(b Bool) bool {
-	if len(a.rules) != len(b.rules) {
-		return false
-	}
-
-	for i := range a.rules {
-		if a.rules[i].pattern != b.rules[i].pattern || a.rules[i].value != b.rules[i].value {
-			return false
-		}
-	}
-
-	return true
-}
-
-func (a boolRule) Equal(b boolRule) bool {
-	return a.pattern == b.pattern && a.value == b.value
+// Equal tests two Bools for equality, used in cmp.
+func (b *Bool) Equal(other *Bool) bool {
+	return b.rules.Equal(other.rules)
 }

--- a/overridable/bool.go
+++ b/overridable/bool.go
@@ -10,7 +10,7 @@ type Bool struct {
 // FromBool creates a Bool representing a static, scalar value.
 func FromBool(b bool) Bool {
 	return Bool{
-		rules: rules{SimpleRule(b)},
+		rules: rules{simpleRule(b)},
 	}
 }
 
@@ -35,7 +35,7 @@ func (b *Bool) MarshalJSON() ([]byte, error) {
 func (b *Bool) UnmarshalJSON(data []byte) error {
 	var all bool
 	if err := json.Unmarshal(data, &all); err == nil {
-		*b = Bool{rules: rules{SimpleRule(all)}}
+		*b = Bool{rules: rules{simpleRule(all)}}
 		return nil
 	}
 
@@ -51,7 +51,7 @@ func (b *Bool) UnmarshalJSON(data []byte) error {
 func (b *Bool) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var all bool
 	if err := unmarshal(&all); err == nil {
-		*b = Bool{rules: rules{SimpleRule(all)}}
+		*b = Bool{rules: rules{simpleRule(all)}}
 		return nil
 	}
 

--- a/overridable/bool_or_string.go
+++ b/overridable/bool_or_string.go
@@ -16,7 +16,7 @@ func FromBoolOrString(v interface{}) BoolOrString {
 	}
 }
 
-// Value returns the PublishedValue for the given repository.
+// Value returns the value for the given repository.
 func (bs *BoolOrString) Value(name string) interface{} {
 	v := bs.rules.Match(name)
 	if v == nil {

--- a/overridable/bool_or_string.go
+++ b/overridable/bool_or_string.go
@@ -12,7 +12,7 @@ type BoolOrString struct {
 // FromBoolOrString creates a BoolOrString representing a static, scalar value.
 func FromBoolOrString(v interface{}) BoolOrString {
 	return BoolOrString{
-		rules: rules{SimpleRule(v)},
+		rules: rules{simpleRule(v)},
 	}
 }
 
@@ -37,12 +37,12 @@ func (bs *BoolOrString) MarshalJSON() ([]byte, error) {
 func (bs *BoolOrString) UnmarshalJSON(data []byte) error {
 	var b bool
 	if err := json.Unmarshal(data, &b); err == nil {
-		*bs = BoolOrString{rules: rules{SimpleRule(b)}}
+		*bs = BoolOrString{rules: rules{simpleRule(b)}}
 		return nil
 	}
 	var s string
 	if err := json.Unmarshal(data, &s); err == nil {
-		*bs = BoolOrString{rules: rules{SimpleRule(s)}}
+		*bs = BoolOrString{rules: rules{simpleRule(s)}}
 		return nil
 	}
 
@@ -58,13 +58,13 @@ func (bs *BoolOrString) UnmarshalJSON(data []byte) error {
 func (bs *BoolOrString) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var b bool
 	if err := unmarshal(&b); err == nil {
-		*bs = BoolOrString{rules: rules{SimpleRule(b)}}
+		*bs = BoolOrString{rules: rules{simpleRule(b)}}
 		return nil
 	}
 
 	var s string
 	if err := unmarshal(&s); err == nil {
-		*bs = BoolOrString{rules: rules{SimpleRule(s)}}
+		*bs = BoolOrString{rules: rules{simpleRule(s)}}
 		return nil
 	}
 

--- a/overridable/bool_or_string.go
+++ b/overridable/bool_or_string.go
@@ -1,0 +1,74 @@
+package overridable
+
+import (
+	"encoding/json"
+)
+
+// BoolOrString is a set of rules that either evaluate to a string or a bool.
+type BoolOrString struct {
+	rules rules
+}
+
+// FromBoolOrString creates a BoolOrString representing a static, scalar value.
+func FromBoolOrString(v interface{}) BoolOrString {
+	return BoolOrString{
+		rules: rules{SimpleRule(v)},
+	}
+}
+
+// Value returns the PublishedValue for the given repository.
+func (bs *BoolOrString) Value(name string) interface{} {
+	v := bs.rules.Match(name)
+	if v == nil {
+		return false
+	}
+	return v
+}
+
+// UnmarshalJSON unmarshalls a JSON value into a Publish.
+func (bs *BoolOrString) UnmarshalJSON(data []byte) error {
+	var b bool
+	if err := json.Unmarshal(data, &b); err == nil {
+		*bs = BoolOrString{rules: rules{SimpleRule(b)}}
+		return nil
+	}
+	var s string
+	if err := json.Unmarshal(data, &s); err == nil {
+		*bs = BoolOrString{rules: rules{SimpleRule(s)}}
+		return nil
+	}
+
+	var c complex
+	if err := json.Unmarshal(data, &c); err != nil {
+		return err
+	}
+
+	return bs.rules.hydrateFromComplex(c)
+}
+
+// UnmarshalYAML unmarshalls a YAML value into a Publish.
+func (bs *BoolOrString) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var b bool
+	if err := unmarshal(&b); err == nil {
+		*bs = BoolOrString{rules: rules{SimpleRule(b)}}
+		return nil
+	}
+
+	var s string
+	if err := unmarshal(&s); err == nil {
+		*bs = BoolOrString{rules: rules{SimpleRule(s)}}
+		return nil
+	}
+
+	var c complex
+	if err := unmarshal(&c); err != nil {
+		return err
+	}
+
+	return bs.rules.hydrateFromComplex(c)
+}
+
+// Equal tests two BoolOrStrings for equality, used in cmp.
+func (bs *BoolOrString) Equal(other *BoolOrString) bool {
+	return bs.rules.Equal(other.rules)
+}

--- a/overridable/bool_or_string.go
+++ b/overridable/bool_or_string.go
@@ -25,6 +25,14 @@ func (bs *BoolOrString) Value(name string) interface{} {
 	return v
 }
 
+// MarshalJSON encodes the BoolOrString overridable to a json representation.
+func (bs *BoolOrString) MarshalJSON() ([]byte, error) {
+	if len(bs.rules) == 0 {
+		return []byte("false"), nil
+	}
+	return json.Marshal(bs.rules)
+}
+
 // UnmarshalJSON unmarshalls a JSON value into a Publish.
 func (bs *BoolOrString) UnmarshalJSON(data []byte) error {
 	var b bool

--- a/overridable/bool_or_string_test.go
+++ b/overridable/bool_or_string_test.go
@@ -1,0 +1,91 @@
+package overridable
+
+import "testing"
+
+func TestBoolOrStringIs(t *testing.T) {
+	for name, tc := range map[string]struct {
+		def        BoolOrString
+		input      string
+		wantParsed interface{}
+	}{
+		"wildcard false": {
+			def: BoolOrString{
+				rules: rules{{pattern: allPattern, value: false}},
+			},
+			input:      "foo",
+			wantParsed: false,
+		},
+		"wildcard true": {
+			def: BoolOrString{
+				rules: rules{{pattern: allPattern, value: true}},
+			},
+			input:      "foo",
+			wantParsed: true,
+		},
+		"wildcard string": {
+			def: BoolOrString{
+				rules: rules{{pattern: allPattern, value: "draft"}},
+			},
+			input:      "foo",
+			wantParsed: "draft",
+		},
+		"list exhausted": {
+			def: BoolOrString{
+				rules: rules{{pattern: "bar*", value: true}},
+			},
+			input:      "foo",
+			wantParsed: false,
+		},
+		"single match": {
+			def: BoolOrString{
+				rules: rules{{pattern: "bar*", value: true}},
+			},
+			input:      "bar",
+			wantParsed: true,
+		},
+		"multiple matches": {
+			def: BoolOrString{
+				rules: rules{
+					{pattern: allPattern, value: true},
+					{pattern: "bar*", value: false},
+				},
+			},
+			input:      "bar",
+			wantParsed: false,
+		},
+		"multiple matches string": {
+			def: BoolOrString{
+				rules: rules{
+					{pattern: allPattern, value: true},
+					{pattern: "bar*", value: "draft"},
+				},
+			},
+			input:      "bar",
+			wantParsed: "draft",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := initBoolOrString(&tc.def); err != nil {
+				t.Fatal(err)
+			}
+
+			if have := tc.def.Value(tc.input); have != tc.wantParsed {
+				t.Errorf("unexpected value: have=%v want=%v", have, tc.wantParsed)
+			}
+		})
+	}
+}
+
+// initBoolOrString ensures all rules are compiled.
+func initBoolOrString(r *BoolOrString) (err error) {
+	for i, rule := range r.rules {
+		if rule.compiled == nil {
+			r.rules[i], err = newRule(rule.pattern, rule.value)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/overridable/bool_or_string_test.go
+++ b/overridable/bool_or_string_test.go
@@ -1,6 +1,12 @@
 package overridable
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"gopkg.in/yaml.v2"
+)
 
 func TestBoolOrStringIs(t *testing.T) {
 	for name, tc := range map[string]struct {
@@ -74,6 +80,149 @@ func TestBoolOrStringIs(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBoolOrStringMarshalJSON(t *testing.T) {
+	bs := BoolOrString{
+		rules{
+			{pattern: allPattern, value: true},
+			{pattern: "bar*", value: false},
+			{pattern: "foo*", value: "draft"},
+		},
+	}
+	data, err := json.Marshal(&bs)
+	if err != nil {
+		t.Errorf("unexpected non-nil error: %v", err)
+	}
+	if have, want := string(data), `[{"*":true},{"bar*":false},{"foo*":"draft"}]`; have != want {
+		t.Errorf("unexpected JSON: have=%q want=%q", have, want)
+	}
+}
+
+func TestBoolOrStringUnmarshalJSON(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		for name, tc := range map[string]struct {
+			in   string
+			want BoolOrString
+		}{
+			"single bool": {
+				in: `true`,
+				want: BoolOrString{
+					rules: rules{
+						{pattern: allPattern, value: true},
+					},
+				},
+			},
+			"single string": {
+				in: `"draft"`,
+				want: BoolOrString{
+					rules: rules{
+						{pattern: allPattern, value: "draft"},
+					},
+				},
+			},
+			"list": {
+				in: `[{"foo*":"bar"}]`,
+				want: BoolOrString{
+					rules: rules{
+						{pattern: "foo*", value: "bar"},
+					},
+				},
+			},
+		} {
+			t.Run(name, func(t *testing.T) {
+				var have BoolOrString
+				if err := json.Unmarshal([]byte(tc.in), &have); err != nil {
+					t.Errorf("unexpected non-nil error: %v", err)
+				}
+				if diff := cmp.Diff(&have, &tc.want); diff != "" {
+					t.Errorf("unexpected BoolOrString: %s", diff)
+				}
+			})
+		}
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		for name, in := range map[string]string{
+			"empty object":    `[{}]`,
+			"too many fields": `[{"foo": true,"bar":false}]`,
+			"invalid glob":    `[{"[":false}]`,
+		} {
+			t.Run(name, func(t *testing.T) {
+				var have BoolOrString
+				if err := json.Unmarshal([]byte(in), &have); err == nil {
+					t.Error("unexpected nil error")
+				}
+			})
+		}
+	})
+}
+
+func TestBoolOrStringYAML(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		for name, tc := range map[string]struct {
+			in   string
+			want BoolOrString
+		}{
+			"single false": {
+				in: `false`,
+				want: BoolOrString{
+					rules: rules{
+						{pattern: allPattern, value: false},
+					},
+				},
+			},
+			"single true": {
+				in: `true`,
+				want: BoolOrString{
+					rules: rules{
+						{pattern: allPattern, value: true},
+					},
+				},
+			},
+			"empty list": {
+				in: `[]`,
+				want: BoolOrString{
+					rules: rules{},
+				},
+			},
+			"multiple rule list": {
+				in: "- \"*\": true\n- github.com/sourcegraph/*: false\n- github.com/sd9/*: draft",
+				want: BoolOrString{
+					rules: rules{
+						{pattern: allPattern, value: true},
+						{pattern: "github.com/sourcegraph/*", value: false},
+						{pattern: "github.com/sd9/*", value: "draft"},
+					},
+				},
+			},
+		} {
+			t.Run(name, func(t *testing.T) {
+				var have BoolOrString
+				if err := yaml.Unmarshal([]byte(tc.in), &have); err != nil {
+					t.Errorf("unexpected non-nil error: %v", err)
+				}
+				if diff := cmp.Diff(&have, &tc.want); diff != "" {
+					t.Errorf("unexpected BoolOrString: %s", diff)
+				}
+			})
+		}
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		for name, in := range map[string]string{
+			"empty object":    `- {}`,
+			"too many fields": `- {"foo": true, "bar": false}`,
+			"invalid glob":    `- "[": false`,
+		} {
+			t.Run(name, func(t *testing.T) {
+				var have BoolOrString
+				if err := yaml.Unmarshal([]byte(in), &have); err == nil {
+					t.Error("unexpected nil error")
+				}
+			})
+		}
+	})
 }
 
 // initBoolOrString ensures all rules are compiled.

--- a/overridable/bool_test.go
+++ b/overridable/bool_test.go
@@ -8,12 +8,6 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-func TestBoolInvalid(t *testing.T) {
-	if _, err := newRule("[", true); err == nil {
-		t.Error("unexpected nil error")
-	}
-}
-
 func TestBoolIs(t *testing.T) {
 	for name, tc := range map[string]struct {
 		in   Bool
@@ -71,48 +65,19 @@ func TestBoolIs(t *testing.T) {
 	}
 }
 
-func TestBoolMarshalJSON(t *testing.T) {
-	for name, tc := range map[string]struct {
-		in   Bool
-		want string
-	}{
-		"no rules": {
-			in: Bool{
-				rules: rules{},
-			},
-			want: `false`,
+func TestBoolgMarshalJSON(t *testing.T) {
+	bs := Bool{
+		rules{
+			{pattern: allPattern, value: true},
+			{pattern: "bar*", value: false},
 		},
-		"one wildcard rule": {
-			in: Bool{
-				rules: rules{{pattern: allPattern, value: true}},
-			},
-			want: `true`,
-		},
-		"one non-wildcard rule": {
-			in: Bool{
-				rules: rules{{pattern: "bar*", value: true}},
-			},
-			want: `[{"bar*":true}]`,
-		},
-		"multiple rules": {
-			in: Bool{
-				rules: rules{
-					{pattern: allPattern, value: true},
-					{pattern: "bar*", value: false},
-				},
-			},
-			want: `[{"*":true},{"bar*":false}]`,
-		},
-	} {
-		t.Run(name, func(t *testing.T) {
-			data, err := json.Marshal(&tc.in)
-			if err != nil {
-				t.Errorf("unexpected non-nil error: %v", err)
-			}
-			if string(data) != tc.want {
-				t.Errorf("unexpected JSON: have=%q want=%q", string(data), tc.want)
-			}
-		})
+	}
+	data, err := json.Marshal(&bs)
+	if err != nil {
+		t.Errorf("unexpected non-nil error: %v", err)
+	}
+	if have, want := string(data), `[{"*":true},{"bar*":false}]`; have != want {
+		t.Errorf("unexpected JSON: have=%q want=%q", have, want)
 	}
 }
 

--- a/overridable/bool_test.go
+++ b/overridable/bool_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestBoolInvalid(t *testing.T) {
-	if _, err := newBoolRule("[", true); err == nil {
+	if _, err := newRule("[", true); err == nil {
 		t.Error("unexpected nil error")
 	}
 }
@@ -22,35 +22,35 @@ func TestBoolIs(t *testing.T) {
 	}{
 		"wildcard false": {
 			in: Bool{
-				rules: []*boolRule{{pattern: allPattern, value: false}},
+				rules: rules{{pattern: allPattern, value: false}},
 			},
 			name: "foo",
 			want: false,
 		},
 		"wildcard true": {
 			in: Bool{
-				rules: []*boolRule{{pattern: allPattern, value: true}},
+				rules: rules{{pattern: allPattern, value: true}},
 			},
 			name: "foo",
 			want: true,
 		},
 		"list exhausted": {
 			in: Bool{
-				rules: []*boolRule{{pattern: "bar*", value: true}},
+				rules: rules{{pattern: "bar*", value: true}},
 			},
 			name: "foo",
 			want: false,
 		},
 		"single match": {
 			in: Bool{
-				rules: []*boolRule{{pattern: "bar*", value: true}},
+				rules: rules{{pattern: "bar*", value: true}},
 			},
 			name: "bar",
 			want: true,
 		},
 		"multiple matches": {
 			in: Bool{
-				rules: []*boolRule{
+				rules: rules{
 					{pattern: allPattern, value: true},
 					{pattern: "bar*", value: false},
 				},
@@ -78,25 +78,25 @@ func TestBoolMarshalJSON(t *testing.T) {
 	}{
 		"no rules": {
 			in: Bool{
-				rules: []*boolRule{},
+				rules: rules{},
 			},
 			want: `false`,
 		},
 		"one wildcard rule": {
 			in: Bool{
-				rules: []*boolRule{{pattern: allPattern, value: true}},
+				rules: rules{{pattern: allPattern, value: true}},
 			},
 			want: `true`,
 		},
 		"one non-wildcard rule": {
 			in: Bool{
-				rules: []*boolRule{{pattern: "bar*", value: true}},
+				rules: rules{{pattern: "bar*", value: true}},
 			},
 			want: `[{"bar*":true}]`,
 		},
 		"multiple rules": {
 			in: Bool{
-				rules: []*boolRule{
+				rules: rules{
 					{pattern: allPattern, value: true},
 					{pattern: "bar*", value: false},
 				},
@@ -125,7 +125,7 @@ func TestBoolUnmarshalJSON(t *testing.T) {
 			"single false": {
 				in: `false`,
 				want: Bool{
-					rules: []*boolRule{
+					rules: rules{
 						{pattern: allPattern, value: false},
 					},
 				},
@@ -133,7 +133,7 @@ func TestBoolUnmarshalJSON(t *testing.T) {
 			"single true": {
 				in: `true`,
 				want: Bool{
-					rules: []*boolRule{
+					rules: rules{
 						{pattern: allPattern, value: true},
 					},
 				},
@@ -141,13 +141,13 @@ func TestBoolUnmarshalJSON(t *testing.T) {
 			"empty list": {
 				in: `[]`,
 				want: Bool{
-					rules: []*boolRule{},
+					rules: rules{},
 				},
 			},
 			"multiple rule list": {
 				in: `[{"*":true},{"github.com/sourcegraph/*":false}]`,
 				want: Bool{
-					rules: []*boolRule{
+					rules: rules{
 						{pattern: allPattern, value: true},
 						{pattern: "github.com/sourcegraph/*", value: false},
 					},
@@ -192,7 +192,7 @@ func TestBoolYAML(t *testing.T) {
 			"single false": {
 				in: `false`,
 				want: Bool{
-					rules: []*boolRule{
+					rules: rules{
 						{pattern: allPattern, value: false},
 					},
 				},
@@ -200,7 +200,7 @@ func TestBoolYAML(t *testing.T) {
 			"single true": {
 				in: `true`,
 				want: Bool{
-					rules: []*boolRule{
+					rules: rules{
 						{pattern: allPattern, value: true},
 					},
 				},
@@ -208,13 +208,13 @@ func TestBoolYAML(t *testing.T) {
 			"empty list": {
 				in: `[]`,
 				want: Bool{
-					rules: []*boolRule{},
+					rules: rules{},
 				},
 			},
 			"multiple rule list": {
 				in: "- \"*\": true\n- github.com/sourcegraph/*: false",
 				want: Bool{
-					rules: []*boolRule{
+					rules: rules{
 						{pattern: allPattern, value: true},
 						{pattern: "github.com/sourcegraph/*", value: false},
 					},
@@ -254,7 +254,7 @@ func TestBoolYAML(t *testing.T) {
 func initBool(b *Bool) (err error) {
 	for i, rule := range b.rules {
 		if rule.compiled == nil {
-			b.rules[i], err = newBoolRule(rule.pattern, rule.value)
+			b.rules[i], err = newRule(rule.pattern, rule.value)
 			if err != nil {
 				return err
 			}

--- a/overridable/bool_test.go
+++ b/overridable/bool_test.go
@@ -65,7 +65,7 @@ func TestBoolIs(t *testing.T) {
 	}
 }
 
-func TestBoolgMarshalJSON(t *testing.T) {
+func TestBoolMarshalJSON(t *testing.T) {
 	bs := Bool{
 		rules{
 			{pattern: allPattern, value: true},

--- a/overridable/doc.go
+++ b/overridable/doc.go
@@ -1,3 +1,0 @@
-// Package overridable provides data types representing values in campaign
-// specs that can be overridden for specific repositories.
-package overridable

--- a/overridable/doc.go
+++ b/overridable/doc.go
@@ -1,0 +1,3 @@
+// Package overridable provides data types representing values in campaign
+// specs that can be overridden for specific repositories.
+package overridable

--- a/overridable/overridable.go
+++ b/overridable/overridable.go
@@ -12,8 +12,8 @@ import (
 // allPattern is used to define default rules for the simple scalar case.
 const allPattern = "*"
 
-// SimpleRule creates the simplest of rules for the given value: `"*": value`.
-func SimpleRule(v interface{}) *rule {
+// simpleRule creates the simplest of rules for the given value: `"*": value`.
+func simpleRule(v interface{}) *rule {
 	r, err := newRule(allPattern, v)
 	if err != nil {
 		// Since we control the pattern being compiled, an error should never

--- a/overridable/overridable.go
+++ b/overridable/overridable.go
@@ -1,0 +1,116 @@
+// Package overridable provides data types representing values in campaign
+// specs that can be overridden for specific repositories.
+package overridable
+
+import (
+	"encoding/json"
+
+	"github.com/gobwas/glob"
+	"github.com/pkg/errors"
+)
+
+// allPattern is used to define default rules for the simple scalar case.
+const allPattern = "*"
+
+// SimpleRule creates the simplest of rules for the given value: `"*": value`.
+func SimpleRule(v interface{}) *rule {
+	r, err := newRule(allPattern, v)
+	if err != nil {
+		// Since we control the pattern being compiled, an error should never
+		// occur.
+		panic(err)
+	}
+
+	return r
+}
+
+type complex []map[string]interface{}
+
+type rule struct {
+	pattern  string
+	compiled glob.Glob
+	value    interface{}
+}
+
+// newRule builds a new rule instance, ensuring that the glob pattern
+// is compiled.
+func newRule(pattern string, value interface{}) (*rule, error) {
+	compiled, err := glob.Compile(pattern)
+	if err != nil {
+		return nil, err
+	}
+
+	return &rule{
+		pattern:  pattern,
+		compiled: compiled,
+		value:    value,
+	}, nil
+}
+
+func (a *rule) Equal(b *rule) bool {
+	return a.pattern == b.pattern && a.value == b.value
+}
+
+type rules []*rule
+
+// Match matches the given repository name against all rules, returning the rule value that matches at last, or nil if none match.
+func (r rules) Match(name string) interface{} {
+	// We want the last match to win, so we'll iterate in reverse order.
+	for i := len(r) - 1; i >= 0; i-- {
+		if r[i].compiled.Match(name) {
+			return r[i].value
+		}
+	}
+	return nil
+}
+
+// MarshalJSON marshalls the bool into its JSON representation, which will
+// either be a literal or an array of objects.
+func (r rules) MarshalJSON() ([]byte, error) {
+	if len(r) == 1 && r[0].pattern == allPattern {
+		return json.Marshal(r[0].value)
+	}
+
+	rules := []map[string]interface{}{}
+	for _, rule := range r {
+		rules = append(rules, map[string]interface{}{
+			rule.pattern: rule.value,
+		})
+	}
+	return json.Marshal(rules)
+}
+
+// hydrateFromComplex builds an array of rules out of a complex value.
+func (r *rules) hydrateFromComplex(c []map[string]interface{}) error {
+	*r = make(rules, len(c))
+	for i, rule := range c {
+		if len(rule) != 1 {
+			return errors.Errorf("unexpected number of elements in the array at entry %d: %d (must be 1)", i, len(rule))
+		}
+		for pattern, value := range rule {
+			var err error
+			(*r)[i], err = newRule(pattern, value)
+			if err != nil {
+				return errors.Wrapf(err, "building rule for array entry %d", i)
+			}
+		}
+	}
+	return nil
+}
+
+// Equal tests two rules for equality. Used in cmp.
+func (r rules) Equal(other rules) bool {
+	if len(r) != len(other) {
+		return false
+	}
+
+	for i := range r {
+		a := r[i]
+		b := other[i]
+		if !a.Equal(b) {
+			return false
+		}
+	}
+
+	return true
+}

--- a/overridable/overridable_test.go
+++ b/overridable/overridable_test.go
@@ -1,0 +1,50 @@
+package overridable
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestRuleInvalid(t *testing.T) {
+	if _, err := newRule("[", true); err == nil {
+		t.Error("unexpected nil error")
+	}
+}
+
+func TestRulesMarshalJSON(t *testing.T) {
+	for name, tc := range map[string]struct {
+		in   rules
+		want string
+	}{
+		"no rules": {
+			in:   rules{},
+			want: `[]`,
+		},
+		"one wildcard rule": {
+			in:   rules{{pattern: allPattern, value: true}},
+			want: `true`,
+		},
+		"one non-wildcard rule": {
+			in:   rules{{pattern: "bar*", value: true}},
+			want: `[{"bar*":true}]`,
+		},
+		"multiple rules": {
+			in: rules{
+				{pattern: allPattern, value: true},
+				{pattern: "bar*", value: false},
+				{pattern: "foo*", value: "draft"},
+			},
+			want: `[{"*":true},{"bar*":false},{"foo*":"draft"}]`,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			data, err := json.Marshal(&tc.in)
+			if err != nil {
+				t.Errorf("unexpected non-nil error: %v", err)
+			}
+			if string(data) != tc.want {
+				t.Errorf("unexpected JSON: have=%q want=%q", string(data), tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This is the first PR in the series of https://github.com/sourcegraph/sourcegraph/issues/7998. It adds support for the triple value of true/false/"draft", and will be used in src-cli and sg/sg to determine the value of the changeset spec.