### PR TITLE
Add json.UnmarshalValidate to allow skipping YAML parser

### DIFF
--- a/json/validate.go
+++ b/json/validate.go
@@ -1,0 +1,25 @@
+package json
+
+import (
+	"encoding/json"
+
+	"github.com/hashicorp/go-multierror"
+
+	"github.com/sourcegraph/campaignutils/jsonschema"
+)
+
+// UnmarshalValidate validates the JSON input against the provided JSON schema.
+// If the validation is successful the validated input is unmarshalled into the
+// target.
+func UnmarshalValidate(schema string, input []byte, target interface{}) error {
+	var errs *multierror.Error
+	if err := jsonschema.Validate(schema, input); err != nil {
+		errs = multierror.Append(errs, err)
+	}
+
+	if err := json.Unmarshal(input, target); err != nil {
+		errs = multierror.Append(errs, err)
+	}
+
+	return errs.ErrorOrNil()
+}

--- a/json/validate_test.go
+++ b/json/validate_test.go
@@ -1,0 +1,56 @@
+package json
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestUnmarshalValidate(t *testing.T) {
+	type targetType struct {
+		A string
+		B int
+	}
+
+	schema := `{
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$id": "https://github.com/sourcegraph/campaignutils/schema/test.schema.json",
+        "type": "object",
+        "properties": {
+            "a": { "type": "string" },
+            "b": { "type": "integer" }
+        }
+    }`
+
+	t.Run("bad schema", func(t *testing.T) {
+		var target targetType
+		if err := UnmarshalValidate("{", []byte(""), &target); err == nil {
+			t.Error("unexpected nil error")
+		} else if !strings.Contains(err.Error(), "failed to compile JSON schema") {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("invalid input", func(t *testing.T) {
+		var target targetType
+		if err := UnmarshalValidate(schema, []byte("b: bar"), &target); err == nil {
+			t.Error("unexpected nil error")
+		} else if !strings.Contains(err.Error(), "invalid character") {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("success", func(t *testing.T) {
+		input := `{"a": "hello", "b": 42}`
+
+		var target targetType
+		if err := UnmarshalValidate(schema, []byte(input), &target); err != nil {
+			t.Errorf("unexpected non-nil error: %v", err)
+		}
+
+		if diff := cmp.Diff(target, targetType{"hello", 42}); diff != "" {
+			t.Errorf("unexpected target value:\n%s", diff)
+		}
+	})
+}

--- a/jsonschema/jsonschema.go
+++ b/jsonschema/jsonschema.go
@@ -1,0 +1,36 @@
+package jsonschema
+
+import (
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/pkg/errors"
+	"github.com/xeipuuv/gojsonschema"
+)
+
+// Validate validates the given input against the JSON schema.
+//
+// It returns either nil, in case the input is valid, or an error.
+func Validate(schema string, input []byte) error {
+	sl := gojsonschema.NewSchemaLoader()
+	sc, err := sl.Compile(gojsonschema.NewStringLoader(schema))
+	if err != nil {
+		return errors.Wrap(err, "failed to compile JSON schema")
+	}
+
+	res, err := sc.Validate(gojsonschema.NewBytesLoader(input))
+	if err != nil {
+		return errors.Wrap(err, "failed to validate input against schema")
+	}
+
+	var errs *multierror.Error
+	for _, err := range res.Errors() {
+		e := err.String()
+		// Remove `(root): ` from error formatting since these errors are
+		// presented to users.
+		e = strings.TrimPrefix(e, "(root): ")
+		errs = multierror.Append(errs, errors.New(e))
+	}
+
+	return errs.ErrorOrNil()
+}

--- a/yaml/validate.go
+++ b/yaml/validate.go
@@ -2,12 +2,12 @@ package yaml
 
 import (
 	"encoding/json"
-	"strings"
 
 	"github.com/ghodss/yaml"
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
-	"github.com/xeipuuv/gojsonschema"
+
+	"github.com/sourcegraph/campaignutils/jsonschema"
 
 	yamlv3 "gopkg.in/yaml.v3"
 )
@@ -16,29 +16,14 @@ import (
 // the provided JSON schema. If the validation is successful the validated
 // input is unmarshalled into the target.
 func UnmarshalValidate(schema string, input []byte, target interface{}) error {
-	sl := gojsonschema.NewSchemaLoader()
-	sc, err := sl.Compile(gojsonschema.NewStringLoader(schema))
-	if err != nil {
-		return errors.Wrap(err, "failed to compile JSON schema")
-	}
-
 	normalized, err := yaml.YAMLToJSONCustom(input, yamlv3.Unmarshal)
 	if err != nil {
 		return errors.Wrapf(err, "failed to normalize JSON")
 	}
 
-	res, err := sc.Validate(gojsonschema.NewBytesLoader(normalized))
-	if err != nil {
-		return errors.Wrap(err, "failed to validate input against schema")
-	}
-
 	var errs *multierror.Error
-	for _, err := range res.Errors() {
-		e := err.String()
-		// Remove `(root): ` from error formatting since these errors are
-		// presented to users.
-		e = strings.TrimPrefix(e, "(root): ")
-		errs = multierror.Append(errs, errors.New(e))
+	if err := jsonschema.Validate(schema, normalized); err != nil {
+		errs = multierror.Append(errs, err)
 	}
 
 	if err := json.Unmarshal(normalized, target); err != nil {


### PR DESCRIPTION
This is needed to fix https://github.com/sourcegraph/sourcegraph/issues/16081 because in `sourcegraph/sourcegraph` we parse the input to `createChangesetSpec` (which contains the complete diff) with the YAML parser, which chokes on weird characters (see #16081 for more details).

With this function we can skip the YAML parser when validating a `ChangesetSpec` here:

https://github.com/sourcegraph/sourcegraph/blob/67a926c4563945d5a3a5599110cbbfafdd18a628/internal/campaigns/changeset_spec.go#L104-L107

