### PR TITLE
Add (*BoolOrString).ValueWithSuffix method

### DIFF
--- a/overridable/bool_or_string.go
+++ b/overridable/bool_or_string.go
@@ -25,6 +25,15 @@ func (bs *BoolOrString) Value(name string) interface{} {
 	return v
 }
 
+// ValueWithSuffix returns the value for the given repository and branch name.
+func (bs *BoolOrString) ValueWithSuffix(name, suffix string) interface{} {
+	v := bs.rules.MatchWithSuffix(name, suffix)
+	if v == nil {
+		return false
+	}
+	return v
+}
+
 // MarshalJSON encodes the BoolOrString overridable to a json representation.
 func (bs BoolOrString) MarshalJSON() ([]byte, error) {
 	if len(bs.rules) == 0 {

--- a/overridable/overridable.go
+++ b/overridable/overridable.go
@@ -27,6 +27,7 @@ func simpleRule(v interface{}) *rule {
 
 type complex []map[string]interface{}
 
+
 type rule struct {
 	// pattern is the glob-syntax pattern, such as "a/b/ceee-*"
 	pattern string
@@ -41,7 +42,7 @@ type rule struct {
 // is compiled.
 func newRule(pattern string, value interface{}) (*rule, error) {
 	var suffix string
-	split := strings.Split(pattern, "@")
+	split := strings.SplitN(pattern, "@", 2)
 	if len(split) > 1 {
 		pattern = split[0]
 		suffix = split[1]

--- a/overridable/overridable.go
+++ b/overridable/overridable.go
@@ -4,6 +4,7 @@ package overridable
 
 import (
 	"encoding/json"
+	"strings"
 
 	"github.com/gobwas/glob"
 	"github.com/pkg/errors"
@@ -27,7 +28,11 @@ func simpleRule(v interface{}) *rule {
 type complex []map[string]interface{}
 
 type rule struct {
-	pattern  string
+	// pattern is the glob-syntax pattern, such as "a/b/ceee-*"
+	pattern string
+	// patternSuffix is an optional suffix that can be appended to the pattern with "@"
+	patternSuffix string
+
 	compiled glob.Glob
 	value    interface{}
 }
@@ -35,15 +40,23 @@ type rule struct {
 // newRule builds a new rule instance, ensuring that the glob pattern
 // is compiled.
 func newRule(pattern string, value interface{}) (*rule, error) {
+	var suffix string
+	split := strings.Split(pattern, "@")
+	if len(split) > 1 {
+		pattern = split[0]
+		suffix = split[1]
+	}
+
 	compiled, err := glob.Compile(pattern)
 	if err != nil {
 		return nil, err
 	}
 
 	return &rule{
-		pattern:  pattern,
-		compiled: compiled,
-		value:    value,
+		pattern:       pattern,
+		patternSuffix: suffix,
+		compiled:      compiled,
+		value:         value,
 	}, nil
 }
 
@@ -58,6 +71,19 @@ func (r rules) Match(name string) interface{} {
 	// We want the last match to win, so we'll iterate in reverse order.
 	for i := len(r) - 1; i >= 0; i-- {
 		if r[i].compiled.Match(name) {
+			return r[i].value
+		}
+	}
+	return nil
+}
+
+// MatchWithSuffix matches the given repository name against all rules and the
+// suffix against provided pattern suffix, returning the rule value that matches
+// at last, or nil if none match.
+func (r rules) MatchWithSuffix(name, suffix string) interface{} {
+	// We want the last match to win, so we'll iterate in reverse order.
+	for i := len(r) - 1; i >= 0; i-- {
+		if r[i].compiled.Match(name) && (r[i].patternSuffix == "" || r[i].patternSuffix == suffix) {
 			return r[i].value
 		}
 	}


### PR DESCRIPTION
This adds the ability for rules to have a suffix, specified with `@<suffix>`. Examples:

- `my-glob-stri*@cool-suffix`
- `*@cool-suffix`
- `another*@example`

That's required for https://github.com/sourcegraph/src-cli/pull/461 in which we want to match changesets not only on their repository name but also their branch.

I'm not sure about the naming here, because the naming is pretty general and we're introducing a concrete requirement here (ability to match against one value and check another fixed value). I think it's fine, but looking for suggestions.